### PR TITLE
fix: Remove references to history and HISTORY.rst as HISTORY.rst does not exist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,6 @@ from setuptools import setup, find_packages
 with open("README.rst") as readme_file:
     readme = readme_file.read()
 
-with open("HISTORY.rst") as history_file:
-    history = history_file.read()
-
 requirements = [
     "Click>=7.0",
 ]
@@ -40,7 +37,7 @@ setup(
     },
     install_requires=requirements,
     license="GNU General Public License v3",
-    long_description=readme + "\n\n" + history,
+    long_description=readme,
     include_package_data=True,
     keywords="oval_xml_feed_merge",
     name="oval_xml_feed_merge",


### PR DESCRIPTION
This fixes the package install failure:

```
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [7 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/home/philroche/Working/oval-xml-feed-merge/setup.py", line 10, in <module>
          with open("HISTORY.rst") as history_file:
               ^^^^^^^^^^^^^^^^^^^
      FileNotFoundError: [Errno 2] No such file or directory: 'HISTORY.rst'
      [end of output]

```