### PR TITLE
Fix for building and running the snap on CPC Jenkins

### DIFF
--- a/oval_xml_feed_merge/__init__.py
+++ b/oval_xml_feed_merge/__init__.py
@@ -1,2 +1,2 @@
 """Top-level package for OVAL XML Feed Merge."""
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.1.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/canonical/oval-xml-feed-merge",
-    version="0.1.1",
+    version="0.1.2",
     zip_safe=False,
 )

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: oval-xml-feed-merge
-version: '0.1.1'
+version: '0.1.2'
 base: core22
 summary: A tool to merge OVAL XML feeds
 description: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,4 +30,7 @@ parts:
         - git
         - python3
     stage-packages:
+        - libpython3.10-minimal
+        - libpython3.10-stdlib
         - python3.10-minimal
+        - python3.10-venv


### PR DESCRIPTION
oval-xml-feed-merge invocation after building and installing it as a classic snap through a Jenkins snap build job failed with following errors:
```
$ oval-xml-feed-merge
Could not find platform independent libraries <prefix>
Could not find platform dependent libraries <exec_prefix>
Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
Python path configuration:
  PYTHONHOME = (not set)
  PYTHONPATH = (not set)
  program name = 'python3'
  isolated = 0
  environment = 1
  user site = 1
  import site = 1
  sys._base_executable = '/snap/oval-xml-feed-merge/x7/bin/python3'
  sys.base_prefix = '/usr'
  sys.base_exec_prefix = '/usr'
  sys.platlibdir = 'lib'
  sys.executable = '/snap/oval-xml-feed-merge/x7/bin/python3'
  sys.prefix = '/usr'
  sys.exec_prefix = '/usr'
  sys.path = [
    '/usr/lib/python310.zip',
    '/usr/lib/python3.10',
    '/usr/lib/lib-dynload',
  ]
Fatal Python error: init_fs_encoding: failed to get the Python codec of the filesystem encoding
Python runtime state: core initialized
ModuleNotFoundError: No module named 'encodings'

Current thread 0x00007f6fdd4ac740 (most recent call first):
  <no Python frame>
```

Updated the runtime dependencies to fix this.

**Testing:**
- Tested by building a snap of the current branch and invoking it through a Jenkins job