### PR TITLE
fix: Regenerate OVAL IDs for the OVAL elements in the input XML

### DIFF
--- a/oval_xml_feed_merge/__init__.py
+++ b/oval_xml_feed_merge/__init__.py
@@ -1,2 +1,2 @@
 """Top-level package for OVAL XML Feed Merge."""
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/oval_xml_feed_merge/oval_xml_feed_merge.py
+++ b/oval_xml_feed_merge/oval_xml_feed_merge.py
@@ -2,6 +2,9 @@
 import logging
 from typing import List, IO, Dict
 
+from oval_xml_feed_merge.utils import Utils
+from oval_xml_feed_merge.xml_utils import XMLUtils
+
 from oval_xml_feed_merge.definition_tree import DefinitionTree
 from oval_xml_feed_merge.xml_file import XMLFile
 import xml.etree.ElementTree as ET
@@ -19,8 +22,10 @@ class OvalXMLFeedMerge:
         self.pkgname_to_definition_tree: Dict[
             str, DefinitionTree
         ] = {}  # Map of the package name to "definition" XML element
+        suffix_generator = Utils.next_int(0)
         self.xml_files: List[XMLFile] = [
-            XMLFile(xml_file, self.ns_prefix_map) for xml_file in raw_xml_files
+            XMLFile(XMLUtils.as_string_io_with_regenerated_ids(xml_file, suffix_generator), self.ns_prefix_map)
+            for xml_file in raw_xml_files
         ]  # Input files
         self.output_xml_file: XMLFile = self.setup_output_xml_file(raw_xml_files[-1])  # Bootstrap an object to store
         # the output XML

--- a/oval_xml_feed_merge/utils.py
+++ b/oval_xml_feed_merge/utils.py
@@ -1,0 +1,9 @@
+from typing import Generator
+
+
+class Utils:
+    @staticmethod
+    def next_int(seed: int = 1) -> Generator[int, None, None]:
+        while True:
+            yield seed
+            seed += 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.2
+current_version = 0.1.3
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/canonical/oval-xml-feed-merge",
-    version="0.1.2",
+    version="0.1.3",
     zip_safe=False,
 )

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: oval-xml-feed-merge
-version: '0.1.2'
+version: '0.1.3'
 base: core22
 summary: A tool to merge OVAL XML feeds
 description: |

--- a/tests/test_xml_utils.py
+++ b/tests/test_xml_utils.py
@@ -1,3 +1,5 @@
+from io import StringIO
+from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
@@ -7,6 +9,11 @@ import xml.etree.ElementTree as ET
 
 
 class TestXMLUtils:
+    @staticmethod
+    def _mock_multiprocessing_pool_map(func, it, chunksize):
+        print("Input", it)
+        return map(func, it)
+
     def test_get_xml_root(self):
         """Test that XMLUtils.get_xml_root reads the passed in XML file and returns an XML root element object
         of the XML string read from the file
@@ -53,3 +60,137 @@ class TestXMLUtils:
         assert {ET.tostring(ele, encoding="unicode") for ele in actual_map.values()} == {
             ET.tostring(ele, encoding="unicode") for ele in expected_id_to_element_map.values()
         }
+
+    @pytest.mark.parametrize(
+        "input_file_content, input_file_name, expected_content_after_test",
+        [
+            (
+                "<root>"
+                '<test id="oval:focal.tst:1234" >A test element</test>'
+                '<var id="oval:focal.var:4567" >A var element</var>'
+                "</root>",
+                "random.xml",
+                "<root>"
+                '<test id="oval:focal.tst:12340000000000000001" >A test element</test>'
+                '<var id="oval:focal.var:45670000000000000001" >A var element</var>'
+                "</root>",
+            ),
+        ],
+    )
+    def test_as_string_io_with_regenerated_ids(self, input_file_content, input_file_name, expected_content_after_test):
+        """Test that as_string_io_with_regenerated_ids regenerates IDs and returns a StringIO object"""
+        input_file = StringIO(input_file_content)
+        input_file.name = input_file_name
+
+        def int_gen():
+            while True:
+                yield 1
+
+        result: StringIO = XMLUtils.as_string_io_with_regenerated_ids(input_file, int_gen())
+        assert result.getvalue() == expected_content_after_test
+        assert result.name == input_file_name
+        assert type(result) == StringIO
+
+    @pytest.mark.parametrize(
+        "input_file_content, input_file_name, expected_content_after_test",
+        [
+            (
+                "<root>"
+                '<test id="oval:focal.tst:1234" >A test element</test>'
+                '<var id="oval:focal.var:4567" >A var element</var>'
+                "</root>",
+                "random.xml",
+                "<root>"
+                '<test id="oval:focal.tst:12340000000000000001" >A test element</test>'
+                '<var id="oval:focal.var:45670000000000000001" >A var element</var>'
+                "</root>",
+            ),
+        ],
+    )
+    def test_regenerate_ids(self, input_file_content, input_file_name, expected_content_after_test):
+        """Test that regenerate_ids regenerates IDs and returns a str object"""
+        input_file = StringIO(input_file_content)
+        input_file.name = input_file_name
+
+        def int_gen():
+            while True:
+                yield 1
+
+        result: str = XMLUtils.regenerate_and_replace_ids(input_file, int_gen())
+        assert result == expected_content_after_test
+        assert type(result) == str
+
+    @pytest.mark.parametrize(
+        "input_file_line, input_current_to_new_id_map, expected_return_value",
+        [
+            (
+                '<test id="oval:focal.tst:1234" >A test element</test>'
+                '<var ref_id="oval:focal.tst:1234" >A var element</var>',
+                {"oval:focal.tst:1234": "oval:focal.tst:12340000000000000001"},
+                '<test id="oval:focal.tst:12340000000000000001" >A test element</test>'
+                '<var ref_id="oval:focal.tst:12340000000000000001" >A var element</var>',
+            ),
+        ],
+    )
+    def test_replace_element_ids(self, input_file_line, input_current_to_new_id_map, expected_return_value):
+        """Test that replace_element_ids replaces IDs as expected from input XML"""
+
+        result: str = XMLUtils.replace_element_ids(input_current_to_new_id_map, input_file_line)
+        assert result == expected_return_value
+        assert type(result) == str
+
+    @pytest.mark.parametrize(
+        "input_file_content, file_name, expected_id_map",
+        [
+            (
+                "<root>"
+                '<test id="oval:focal.tst:1234" >A test element</test>'
+                '<var id="oval:focal.var:4567" >A var element</var>'
+                "</root>",
+                "random.xml",
+                {
+                    "oval:focal.tst:1234": "oval:focal.tst:12340000000000000001",
+                    "oval:focal.var:4567": "oval:focal.var:45670000000000000001",
+                },
+            )
+        ],
+    )
+    def test_update_current_to_new_element_id_map(self, input_file_content, file_name, expected_id_map):
+        current_to_new_id_map = {}
+
+        def int_gen():
+            while True:
+                yield 1
+
+        XMLUtils.update_current_to_new_element_id_map(current_to_new_id_map, int_gen(), input_file_content, file_name)
+        assert current_to_new_id_map == expected_id_map
+
+    @pytest.mark.parametrize(
+        "input_file_content, file_name, duplicate_id, expected_id_map",
+        [
+            (
+                "<root>"
+                '<test id="oval:focal.tst:1234" >A test element</test>'
+                '<test id="oval:focal.tst:1234" >A duplicate element</test>'
+                "</root>",
+                "random.xml",
+                "oval:focal.tst:1234",
+                {
+                    "oval:focal.tst:1234": "oval:focal.tst:12340000000000000001",
+                },
+            )
+        ],
+    )
+    @mock.patch("oval_xml_feed_merge.xml_utils.logging.warning")
+    def test_update_current_to_new_element_id_map_log(
+        self, mock_log_warn, input_file_content, file_name, duplicate_id, expected_id_map
+    ):
+        current_to_new_id_map = {}
+
+        def int_gen():
+            while True:
+                yield 1
+
+        XMLUtils.update_current_to_new_element_id_map(current_to_new_id_map, int_gen(), input_file_content, file_name)
+        assert current_to_new_id_map == expected_id_map
+        mock_log_warn.assert_called_with(f"Duplicate element ID: {duplicate_id} in {file_name}")


### PR DESCRIPTION
Merging two OVAL feeds in the same namespaces was failing intermittently as IDs were duplicated across the feeds. This commit adds a fix to regenerate IDs for OVAL elements so that they are unique across all the input feeds.

**Approach:**
1. Create a sequence generator (counts up from 1).
2. For each input XML file:
     a. Find all IDs, append a 16-digit number to the end of each ID. The 16-digit number for each ID is generated incrementally through the sequence generator.
      b. Replace existing IDs with the generated ones.
       c. Create a `StringIO` object from the result string and use that in place of the input XML file.

**Additional notes:**
Using regex would be a better way to find and replace  OVAL IDs and their references. However, that approach is significantly slower (100s of seconds to 10s of seconds) than the current approach of using a string find and replace. 

**Testing:**   
Tested the tool with `focal` and `esm-apps_focal` feeds that had duplicate IDs.    
    1. Merge was successful. Randomly verified a few IDs if all instances were updated. 
    6. Ran an OSCAP OVAL eval, ran without errors.

