### PR TITLE
fix: Preload semaphore wrapper library to allow Python multiprocessing on strict confinement snap

### DIFF
--- a/oval_xml_feed_merge/__init__.py
+++ b/oval_xml_feed_merge/__init__.py
@@ -1,2 +1,2 @@
 """Top-level package for OVAL XML Feed Merge."""
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/run-oval-xml-feed-merge.sh
+++ b/run-oval-xml-feed-merge.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Based on https://forum.snapcraft.io/t/reliable-way-of-detecting-snap-confinement-mode/8896/5
+CONFINEMENT=$(grep confinement $SNAP/meta/snap.yaml|sed 's/^.*: //')
+
+if [ $CONFINEMENT == "strict" ]; then
+  snapcraft-preload $SNAP/bin/oval-xml-feed-merge "$@"
+else
+  oval-xml-feed-merge "$@"
+fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.3
+current_version = 0.1.4
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/canonical/oval-xml-feed-merge",
-    version="0.1.3",
+    version="0.1.4",
     zip_safe=False,
 )

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: oval-xml-feed-merge
-version: '0.1.3'
+version: '0.1.4'
 base: core22
 summary: A tool to merge OVAL XML feeds
 description: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,23 +14,42 @@ confinement: strict
 
 apps:
   oval-xml-feed-merge:
-    command: bin/oval-xml-feed-merge
+    command: bin/run-oval-xml-feed-merge.sh
     plugs:
-        - home
+      - home
 
 
 parts:
+  run-oval-xml-feed-merge:
+    plugin: dump
+    source: .
+    organize:
+      run-oval-xml-feed-merge.sh: bin/run-oval-xml-feed-merge.sh
+    stage:
+      - bin/run-oval-xml-feed-merge.sh
+
   oval-xml-feed-merge:
     plugin: python
     source: .
     source-type: git
-    build-attributes:
-        - enable-patchelf
     build-packages:
-        - git
-        - python3
+      - git
+      - python3
     stage-packages:
-        - libpython3.10-minimal
-        - libpython3.10-stdlib
-        - python3.10-minimal
-        - python3.10-venv
+      - libpython3.10-minimal
+      - libpython3.10-stdlib
+      - python3.10-minimal
+      - python3.10-venv
+    build-attributes:
+      - enable-patchelf
+
+  snapcraft-preload:
+    source: https://github.com/sergiusens/snapcraft-preload.git
+    plugin: cmake
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=/
+    build-packages:
+      - make
+      - on amd64:
+        - gcc-multilib
+        - g++-multilib


### PR DESCRIPTION
**Problem:**

PR #13 introduced Python multiprocessing to regenerate OVAL IDs in the input OVAL XML files.
However, this caused the oval-xml-feed-merge snap to fail with a permission denied error.
This was because snap strict confinement prevented access to semaphores required by Python multiprocessing. Python multiprocessing works without issues when the snap is built with classic confinement.

**Fix:**

This PR adds a preload library (libsnapcraft-preload.so) to work around accessing semaphores in a snap with strict confinement.
We also build the oval-xml-feed-merge snap as a classic snap for Jenkins. In a classic snap the host environment leaks into the snap runtime, and this causes libc conflicts when loading libsnapcraft-preload.so.
To resolve this, this PR also adds a wrapper bash script that determines the snap confinement and loads libsnapcraft-preload.so only when the snap is running with strict confinement. 


**Testing:**  

Tested snap build, install and use on the following setups:
1. My local machine, Ubuntu 22.04 x86_64  and strict confinement
2. GCP VM, Ubuntu 20.04 x86_64 and strict confinement
3. AWS VM, Ubuntu 22.04 aarch64 and strict confinement
4. AWS Jenkins setup, through the snap build, and Anthos upload jobs, Ubuntu 20.04 x86_64 and classic confinement

fixes #14 

