### PR TITLE
Optimize OVAL ID replacement logic

### DIFF
--- a/oval_xml_feed_merge/__init__.py
+++ b/oval_xml_feed_merge/__init__.py
@@ -1,2 +1,2 @@
 """Top-level package for OVAL XML Feed Merge."""
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/oval_xml_feed_merge/oval_xml_feed_merge.py
+++ b/oval_xml_feed_merge/oval_xml_feed_merge.py
@@ -23,8 +23,12 @@ class OvalXMLFeedMerge:
             str, DefinitionTree
         ] = {}  # Map of the package name to "definition" XML element
         suffix_generator = Utils.next_int(0)
+        global_input_id_set = set()  # A global set to track all seen OVAL IDs
         self.xml_files: List[XMLFile] = [
-            XMLFile(XMLUtils.as_string_io_with_regenerated_ids(xml_file, suffix_generator), self.ns_prefix_map)
+            XMLFile(
+                XMLUtils.as_string_io_with_regenerated_ids(xml_file, suffix_generator, global_input_id_set),
+                self.ns_prefix_map,
+            )
             for xml_file in raw_xml_files
         ]  # Input files
         self.output_xml_file: XMLFile = self.setup_output_xml_file(raw_xml_files[-1])  # Bootstrap an object to store

--- a/oval_xml_feed_merge/xml_utils.py
+++ b/oval_xml_feed_merge/xml_utils.py
@@ -6,7 +6,7 @@ import xml.etree.ElementTree as ET
 import logging
 from io import StringIO
 from math import ceil
-from typing import Dict, IO, Generator
+from typing import Dict, IO, Generator, Set, Union
 
 
 class XMLUtils:
@@ -40,54 +40,72 @@ class XMLUtils:
         return id_to_element_map
 
     @staticmethod
-    def as_string_io_with_regenerated_ids(raw_xml_file: IO, suffix_int_generator: Generator[int, None, None]) -> IO:
+    def as_string_io_with_regenerated_ids(
+        raw_xml_file: IO, suffix_int_generator: Generator[int, None, None], global_input_id_set: Set[str]
+    ) -> IO:
         """Returns content within "raw_xml_file" as a StringIO object with new IDs for OVAL elements
         generated using the suffix_int_generator"""
-        xml_file_contents = XMLUtils.regenerate_and_replace_ids(raw_xml_file, suffix_int_generator)
+        xml_file_contents = XMLUtils.regenerate_and_replace_ids(raw_xml_file, suffix_int_generator, global_input_id_set)
         xml_file_as_io = StringIO(xml_file_contents)
         xml_file_as_io.name = raw_xml_file.name
         return xml_file_as_io
 
     @staticmethod
-    def regenerate_and_replace_ids(raw_xml_file: IO, suffix_int_generator: Generator[int, None, None]) -> str:
+    def regenerate_and_replace_ids(
+        raw_xml_file: IO, suffix_int_generator: Generator[int, None, None], global_input_id_set: Set[str]
+    ) -> str:
         """Finds and replaces OVAL element IDs with new IDs in the "raw_xml_file".
         raw_xml_file contents are split and processed by multiple worker processes
         Result is returned as a str"""
         logging.debug("Regenerating OVAL IDs in {}, this may take a while...".format(raw_xml_file.name))
         xml_file_contents = raw_xml_file.read()
         raw_xml_file.seek(0)
-        current_to_new_id_map = {}
+        current_file_old_to_new_id_map = {}
         XMLUtils.update_current_to_new_element_id_map(
-            current_to_new_id_map, suffix_int_generator, xml_file_contents, raw_xml_file.name
+            current_file_old_to_new_id_map,
+            suffix_int_generator,
+            global_input_id_set,
+            xml_file_contents,
+            raw_xml_file.name,
         )
-        curried_replace_element_ids_func = functools.partial(XMLUtils.replace_element_ids, current_to_new_id_map)
+        curried_replace_element_ids_func = functools.partial(
+            XMLUtils.replace_element_ids, current_file_old_to_new_id_map
+        )
         pool = multiprocessing.Pool(8)
         xml_file_lines = xml_file_contents.splitlines()
         xml_file_lines = pool.map(curried_replace_element_ids_func, xml_file_lines, ceil(len(xml_file_lines) / 8))
         return "\n".join(xml_file_lines)
 
     @staticmethod
-    def replace_element_ids(current_to_new_id_map: Dict[str, str], xml_file_line: str) -> str:
-        """Replaces all keys from current_to_new_id_map present in xml_file_line
-        with the replacement mapped in current_to_new_id_map and returns the result str"""
-        for current_element_id, new_element_id in current_to_new_id_map.items():
-            xml_file_line = xml_file_line.replace(current_element_id, new_element_id)
+    def replace_element_ids(current_file_old_to_new_id_map: Dict[str, Union[str, None]], xml_file_line: str) -> str:
+        """Replaces all keys from current_file_old_to_new_id_map present in xml_file_line
+        with the replacement mapped in current_file_old_to_new_id_map and returns the result str"""
+        for current_element_id, new_element_id in current_file_old_to_new_id_map.items():
+            if new_element_id:  # Replace current_element_id only if new_element_id is not None
+                xml_file_line = xml_file_line.replace(current_element_id, new_element_id)
         return xml_file_line
 
     @staticmethod
     def update_current_to_new_element_id_map(
-        current_to_new_id_map: Dict[str, str],
+        current_file_old_to_new_id_map: Dict[str, Union[str, None]],
         suffix_int_generator: Generator[int, None, None],
+        global_input_id_set: Set[str],
         xml_file_content: str,
         raw_xml_file_name: str,
     ):
-        """Finds OVAL element IDs in xml_file_content and updates current_to_new_id_map with the found
-        IDs mapped to new generated ID. IDs are generated using suffix_int_generator"""
+        """Finds OVAL element IDs in xml_file_content and updates current_file_old_to_new_id_map with the found
+        IDs mapped to new generated ID. A new ID is generated only for a duplicate ID.
+        IDs are generated using suffix_int_generator"""
         element_id_regex = re.compile(r'id="(oval:.*?)"\s+')
         for match in element_id_regex.finditer(xml_file_content):
             element_id = match.group(1)
-            if element_id not in current_to_new_id_map:
-                current_to_new_id_map[element_id] = element_id + f"{next(suffix_int_generator):016d}"
-                # 16 decimal digits, enough to cover 2^48 ints
-            else:
+            if element_id in current_file_old_to_new_id_map:  # We have already decided if we need to generate a new ID
+                # for element_id the last time we saw this ID for this file, so we can log a warning and return
                 logging.warning(f"Duplicate element ID: {element_id} in {raw_xml_file_name}")
+                assert element_id in global_input_id_set
+                return
+            current_file_old_to_new_id_map[element_id] = None
+            if element_id in global_input_id_set:
+                current_file_old_to_new_id_map[element_id] = element_id + f"{next(suffix_int_generator):016d}"
+                # 16 decimal digits, enough to cover 2^48 ints
+            global_input_id_set.add(element_id)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.4
+current_version = 0.1.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/canonical/oval-xml-feed-merge",
-    version="0.1.4",
+    version="0.1.5",
     zip_safe=False,
 )

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: oval-xml-feed-merge
-version: '0.1.4'
+version: '0.1.5'
 base: core22
 summary: A tool to merge OVAL XML feeds
 description: |

--- a/tests/test_oval_xml_feed_merge.py
+++ b/tests/test_oval_xml_feed_merge.py
@@ -18,7 +18,7 @@ class TestOvalXMLFeedMergeTestCtor:
     @mock.patch("oval_xml_feed_merge.oval_xml_feed_merge.XMLUtils.as_string_io_with_regenerated_ids")
     def test_ctor(self, mock_as_string_io, mock_xml_file, xml_file_names):
         """Test that OvalXMLFeedMerge constructor initializes all attributes to the expected values"""
-        mock_as_string_io.side_effect = lambda x, y: x
+        mock_as_string_io.side_effect = lambda x, y, z: x
         mock_output_file = MagicMock()
         oxfm = OvalXMLFeedMerge(xml_file_names, mock_output_file)
         calls = []
@@ -208,7 +208,7 @@ class TestOvalXMLFeedMergeSetupOutputXMLFile:
         """Test that the constructor calls setup_output_xml_file. Also test that setup_output_xml_file
         sets up a cleared output_xml_file
         """
-        mock_as_string_io.side_effect = lambda x, y: x
+        mock_as_string_io.side_effect = lambda x, y, z: x
         mock_xml_files = []
         for xml_file_name, content in zip(xml_files, xml_files_contents):
             mock_xml_file = MagicMock(name=xml_file_name)
@@ -221,7 +221,7 @@ class TestOvalXMLFeedMergeSetupOutputXMLFile:
     @mock.patch("oval_xml_feed_merge.oval_xml_feed_merge.XMLUtils.as_string_io_with_regenerated_ids")
     def test_setup_output_xml_file_calls(self, mock_as_string_io, mock_xml_file):
         """Test that setup_output_xml_file makes the expected calls"""
-        mock_as_string_io.side_effect = lambda x, y: x
+        mock_as_string_io.side_effect = lambda x, y, z: x
         xml_file_object = MagicMock()
         mock_xml_file.return_value = xml_file_object
         xml_files = ["test_xml.xml"]


### PR DESCRIPTION
Updated OVAL ID replacement logic to replace ID only in case it is a duplicate as supposed to the current implementation that generates new IDs for each ID in each file.

**Testing:**

Verified manually through random diff checks of merged XML generated with and without the changes. The input XML files had duplicate OVAL IDs.

**Performance:**
Runtime measured using: `time oval-xml-feed-merge oci.com.ubuntu.focal.pkg.oval.xml oci.com.ubuntu.esm-apps_focal.pkg.oval.xml  --output merged.xml --verbose`
Before optimization: 
```
378.33s user 1.17s system 562% cpu 1:07.44 total
```

After optimization: 
```
153.35s user 1.29s system 505% cpu 30.586 total
```

