### PR TITLE
fix: Call console-script and snapcraft-preload script explicitly to avoid infinite loop

### DIFF
--- a/oval_xml_feed_merge/__init__.py
+++ b/oval_xml_feed_merge/__init__.py
@@ -1,2 +1,2 @@
 """Top-level package for OVAL XML Feed Merge."""
-__version__ = "0.1.5"
+__version__ = "0.1.6"

--- a/run-oval-xml-feed-merge.sh
+++ b/run-oval-xml-feed-merge.sh
@@ -4,7 +4,7 @@
 CONFINEMENT=$(grep confinement $SNAP/meta/snap.yaml|sed 's/^.*: //')
 
 if [ $CONFINEMENT == "strict" ]; then
-  snapcraft-preload $SNAP/bin/oval-xml-feed-merge "$@"
+  $SNAP/bin/snapcraft-preload $SNAP/bin/oval-xml-feed-merge "$@"
 else
-  oval-xml-feed-merge "$@"
+  $SNAP/bin/python3 $SNAP/bin/oval-xml-feed-merge "$@"
 fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.5
+current_version = 0.1.6
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/canonical/oval-xml-feed-merge",
-    version="0.1.5",
+    version="0.1.6",
     zip_safe=False,
 )

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: oval-xml-feed-merge
-version: '0.1.5'
+version: '0.1.6'
 base: core22
 summary: A tool to merge OVAL XML feeds
 description: |


### PR DESCRIPTION
Due to some changes in how $PATH is defined in snapcraft 8+ classic snaps we
now need specify the path to the console-script explicitly.

This avoid infinite loop of calling the shell script of the same name.

The loop leads to errors like

```
shell level (1000) too high, resetting to 1
```

Related bug @ https://github.com/canonical/snapcraft/issues/4615
